### PR TITLE
Problem: We don't display a prompt properly after execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause",
   "dependencies": {
+    "@reactivex/rxjs": "^5.0.0-beta.1",
     "chalk": "^1.1.1",
     "enchannel-zmq-backend": "^1.0.0",
     "image-to-ascii": "^2.3.1",


### PR DESCRIPTION
Solution: Handle `execute_reply` and `execute_result`, rely on an `idle` from the current parent message.

Closes #4, #6