### PR TITLE
Problem: spawnteract not giving sys.prefix kernels

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "image-to-ascii": "^2.3.1",
     "marked": "^0.3.5",
     "marked-terminal": "^1.6.1",
-    "spawnteract": "0.0.4",
+    "spawnteract": "0.1.0",
     "temp": "^0.8.3",
     "uuid": "^2.0.1"
   },


### PR DESCRIPTION
Solution: Upgrade spawnteract (https://github.com/nteract/spawnteract/pull/2)