### PR TITLE
Upgrade to image-to-ascii@3.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@ const chalk = require('chalk');
 const marked = require('marked');
 const TerminalRenderer = require('marked-terminal');
 
-const temp = require('temp').track();
 const imageToAscii = require('image-to-ascii');
 
 const fs = require('fs');
@@ -162,19 +161,9 @@ function main(c) {
 
           displayData.subscribe(data => {
             if(data['image/png']) {
-              temp.open('ick-image', (err, info) => {
-                if (err) {
-                  console.error(err);
-                  return;
-                }
-                const decodedData = new Buffer(data['image/png'], 'base64');
-                const writer = fs.createWriteStream(info.path);
-                writer.end(decodedData);
-                writer.on('finish', () => {
-                  imageToAscii(info.path, (imErr, converted) => {
-                    console.log(imErr || converted);
-                  });
-                });
+              const decodedData = new Buffer(data['image/png'], 'base64');
+              imageToAscii(info.path, (imErr, converted) => {
+                console.log(imErr || converted);
               });
             }
             else if(data['text/markdown']) {

--- a/package.json
+++ b/package.json
@@ -15,11 +15,10 @@
     "@reactivex/rxjs": "^5.0.0-beta.1",
     "chalk": "^1.1.1",
     "enchannel-zmq-backend": "^1.0.0",
-    "image-to-ascii": "^2.3.1",
+    "image-to-ascii": "^3.0.0",
     "marked": "^0.3.5",
     "marked-terminal": "^1.6.1",
     "spawnteract": "1.0.0",
-    "temp": "^0.8.3",
     "uuid": "^2.0.1"
   },
   "devDependencies": {},


### PR DESCRIPTION
:warning: This is **not** tested ...but hopefully it works :grin:

---

 - :arrow_up: Upgraded to image-to-ascii@3.0.0
 - :fire: Removed `temp` as dependency, since it is not used anymore.
 - :rocket: Use the buffer object to convert the image in text output.