### PR TITLE
Updated dependency to remove call to fromArray in kernelspec

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
   "dependencies": {
     "@reactivex/rxjs": "5.0.0-beta.2",
     "chalk": "^1.1.1",
-    "enchannel-zmq-backend": "^1.0.0",
+    "enchannel-zmq-backend": "^1.0.1",
     "image-to-ascii": "^3.0.0",
     "marked": "^0.3.5",
     "marked-terminal": "^1.6.1",
-    "spawnteract": "1.0.0",
+    "spawnteract": "2.0.0",
     "uuid": "^2.0.1"
   },
   "devDependencies": {},


### PR DESCRIPTION
Hi, I updated the Spawnteract dependency to 2.0 to remove the call to Observable.fromArray in kernelspec. This fixes the issue referenced in #33 when I clone the repo onto my machine and run
```
cd ~/path/to/ick
npm install
node index.js python3 
```